### PR TITLE
Use LLVM toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ Prerequisites:
 Steps:
 1. Download and install/extract [Xcode](https://developer.apple.com/download/all/?q=Xcode) 15.0 or higher
     - Use `unxip` to extract Xcode if you're on Linux.
-2. Run `./build.sh <linux host> [developer dir]`.
-    - **linux host**: You can pass any Linux host for which a darwin-tools-linux [release](https://github.com/kabiroberai/darwin-tools-linux/releases) exists. e.g. `ubuntu22.04-aarch64`.
-    - **developer dir**: this should be the path to `Xcode.app/Contents/Developer`. On macOS, you can omit this argument to let the script infer it.
+2. Run `./build.sh [developer dir]`.
+    - **developer dir**: this should be the path to `Xcode.app/Contents/Developer`. On macOS, you can omit this argument (or pass `auto`) to let the script infer it.
 
-Find the output at `output/darwin.artifactbundle`.
+Find the output at `output/darwin-linux-$(arch).artifactbundle`.
 
 ## Installing
 
@@ -27,7 +26,7 @@ Prerequisites:
 - `darwin.artifactbundle` built for your host OS (see **Building**)
 
 ```
-swift experimental-sdk install output/darwin.artifactbundle
+swift experimental-sdk install output/darwin-linux-$(arch).artifactbundle
 ```
 
 ## Usage

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ sed 's/$MacOSX_SDK/'"$MacOSX_SDK"'/g; s/$iPhoneOS_SDK/'"$iPhoneOS_SDK"'/g' templ
 echo "Installing toolset..."
 mkdir -p "$bundle/toolset"
 curl -#L "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-${linux_version}.tar.gz" \
-    | tar xzf - -C "$bundle/toolset" --strip-components=2
+    | tar xzf - -C "$bundle/toolset" --strip-components=2 linux/iphone/bin/{dsymutil,libtool}
 
 echo "Installing Developer directories..."
 mkdir -p "$bundle/Developer"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DARWIN_TOOLS_VERSION="1.0.0"
+DARWIN_TOOLS_VERSION="1.0.1"
 
 set -e
 

--- a/build.sh
+++ b/build.sh
@@ -1,23 +1,39 @@
 #!/bin/bash
 
-DARWIN_TOOLS_VERSION="2.4.0"
+DARWIN_TOOLS_VERSION="1.0.0"
 
 set -e
 
-if [[ ($# -ne 1 && $# -ne 2) || $1 == -h || $1 == --help ]]; then
-    echo "Usage: $0 <linux version such as ubuntu22.04> [/path/to/Xcode.app/Contents/Developer]"
+if [[ ($# -gt 2) || $1 == -h || $1 == --help ]]; then
+    echo "Usage: $0 [/path/to/Xcode.app/Contents/Developer|auto] [x86_64|aarch64|auto]"
     exit 1
 fi
 
-linux_version=$1
-if [[ $# == 2 ]]; then
-    dev_dir="$2"
-elif type -p xcode-select &>/dev/null; then
-    dev_dir="$(xcode-select -p)"
-else
-    echo "error: Path to Xcode.app was not supplied; can't infer since we aren't on macOS."
-    exit 1
+dev_dir="${1:-auto}"
+if [[ "${dev_dir}" == auto ]]; then
+    if type -p xcode-select &>/dev/null; then
+        dev_dir="$(xcode-select -p)"
+    else
+        echo "error: Path to Xcode.app was not supplied; can't infer since we aren't on macOS."
+        exit 1
+    fi
 fi
+
+target_arch="${2:-auto}"
+if [[ "${target_arch}" == auto ]]; then
+    target_arch="$(arch)"
+fi
+case "$target_arch" in
+    x86_64) ;;
+    aarch64) ;;
+    arm64) target_arch=aarch64 ;;
+    *)
+        echo "error: Unrecognized architecture '${target_arch}'. Please specify x86_64 or aarch64."
+        exit 1
+        ;;
+esac
+
+echo "Building for ${target_arch} using Xcode at ${dev_dir}..."
 
 if [[ "$(uname -s)" == Darwin ]]; then
     sed_inplace=(-i '')
@@ -43,8 +59,8 @@ sed 's/$MacOSX_SDK/'"$MacOSX_SDK"'/g; s/$iPhoneOS_SDK/'"$iPhoneOS_SDK"'/g' templ
 
 echo "Installing toolset..."
 mkdir -p "$bundle/toolset"
-curl -#L "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-${linux_version}.tar.gz" \
-    | tar xzf - -C "$bundle/toolset" --strip-components=2 linux/iphone/bin/{dsymutil,libtool}
+curl -#L "https://github.com/kabiroberai/darwin-tools-linux-llvm/releases/download/v${DARWIN_TOOLS_VERSION}/toolset-${target_arch}.tar.gz" \
+    | tar xzf - -C "$bundle/toolset"
 
 echo "Installing Developer directories..."
 mkdir -p "$bundle/Developer"
@@ -58,7 +74,7 @@ rsync -aW --relative \
 echo "Packaging..."
 # We need to zip-then-move to avoid appending to an existing zip file.
 (cd "$(dirname "$bundle")" && zip -yqr "$root/staging/darwin.artifactbundle.zip.tmp" "$(basename "$bundle")")
-mv -f "$root/staging/darwin.artifactbundle.zip.tmp" "$root/output/darwin-${linux_version}.artifactbundle.zip"
+mv -f "$root/staging/darwin.artifactbundle.zip.tmp" "$root/output/darwin-linux-${target_arch}.artifactbundle.zip"
 rm -rf staging
 
 echo "Done!"

--- a/layout/toolset.json
+++ b/layout/toolset.json
@@ -2,6 +2,11 @@
     "schemaVersion": "1.0",
     "rootPath": "toolset/bin",
     "linker": {
-        "path": "ld"
+        "path": "ld64.lld"
+    },
+    "swiftCompiler": {
+        "extraCLIOptions": [
+            "-use-ld=lld"
+        ]
     }
 }

--- a/layout/toolset/bin/ld64.lld
+++ b/layout/toolset/bin/ld64.lld
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Old versions of lld choke on -no_warn_duplicate_libraries. Should be fixed in Swift 6.1.
+# https://github.com/swiftlang/llvm-project/commit/39fe729502006f1b108828b75af8d63a27364f80
+
+# TODO: include a real copy of ld64.lld instead. 6.1 on Linux also builds lld without iOS support.
+
+ld64.lld ${@//-no_warn_duplicate_libraries}

--- a/layout/toolset/bin/ld64.lld
+++ b/layout/toolset/bin/ld64.lld
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Old versions of lld choke on -no_warn_duplicate_libraries. Should be fixed in Swift 6.1.
-# https://github.com/swiftlang/llvm-project/commit/39fe729502006f1b108828b75af8d63a27364f80
-
-# TODO: include a real copy of ld64.lld instead. 6.1 on Linux also builds lld without iOS support.
-
-ld64.lld ${@//-no_warn_duplicate_libraries}


### PR DESCRIPTION
We can fully adopt LLVM tools ([dsymutil](https://llvm.org/docs/CommandGuide/dsymutil.html) which is already LLVM-based, but also [llvm-libtool-darwin](https://llvm.org/docs/CommandGuide/llvm-libtool-darwin.html) and [ld64.lld](https://lld.llvm.org/MachO/index.html)) and drop the dependency on the various submodules that darwin-tools-linux pulls in.